### PR TITLE
Sanitize the project dir strings

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -130,22 +130,26 @@ function projectpath(client::Client)
             last(client.env[proj_env_index])
         end
     end
-    if !isnothing(project_index) && project_index < length(client.switches)
+    if !isnothing(project_index) && project_index <= length(client.switches)
         project_path = last(client.switches[project_index])
     end
     if project_path == "@."
         projectfile_path = joinpath(client.cwd, "Project.toml")
         while !ispath(projectfile_path)
             parent = joinpath(projectfile_path |> dirname |> dirname,
-                                "Project.toml")
+                              "Project.toml")
             if parent == projectfile_path
                 projectfile_path = Base.load_path_expand("@v#.#")
             else
                 projectfile_path = parent
             end
         end
-        projectfile_path |> dirname
+        returned_path = projectfile_path |> dirname
     else
-        abspath(client.cwd, project_path)
+        returned_path = abspath(client.cwd, expanduser(project_path))
     end
+    ## make sure a trailing backslash does not make a difference (i.e., xx/ and
+    ## xx will be considered as the same directory)
+    returned_path = rstrip(returned_path, '/')
+    return returned_path
 end


### PR DESCRIPTION
Fix issue when the project_index is the last element in client.switches.

Make sure different versions of the same directory (e.g. ~/X, X/ and X) are actually considered to be the same.