### PR TITLE
Ensure 'project_path' is a String

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -146,6 +146,6 @@ function projectpath(client::Client)
         end
         projectfile_path |> dirname
     else
-        rstrip(abspath(client.cwd, expanduser(project_path)), '/')
+        String(rstrip(abspath(client.cwd, expanduser(project_path)), '/'))
     end
 end


### PR DESCRIPTION
Function `rstrip` returns a SubString, which can sometimes create an error, because `Worker(project::Union{String, Nothing}=nothing)` expects to receive a String.