### PR TITLE
Log revise setting on daemon startup

### DIFF
--- a/src/conductor.jl
+++ b/src/conductor.jl
@@ -55,7 +55,12 @@ function start()
     try
         @log "Preparing worker environment"
         ensure_worker_env()
-        @log "Running on $socket"
+        revise_setting = if haskey(ENV, "JULIA_DAEMON_REVISE")
+            "JULIA_DAEMON_REVISE=$(ENV["JULIA_DAEMON_REVISE"])"
+        else
+            "revise: no (default)"
+        end
+        @log "Running on $socket ($revise_setting)"
         @async create_reserve_worker()
         while true
             serveonce(server)


### PR DESCRIPTION
On startup, logs whether revise is enabled so you can confirm the setting is active