### PR TITLE
Fix arg parsing for no-value switches and add systemd hints

### DIFF
--- a/src/conductor.jl
+++ b/src/conductor.jl
@@ -55,7 +55,12 @@ function start()
     try
         @log "Preparing worker environment"
         ensure_worker_env()
-        @log "Running on $socket"
+        revise_setting = if haskey(ENV, "JULIA_DAEMON_REVISE")
+            "JULIA_DAEMON_REVISE=$(ENV["JULIA_DAEMON_REVISE"])"
+        else
+            "revise: no (default)"
+        end
+        @log "Running on $socket ($revise_setting)"
         @async create_reserve_worker()
         while true
             serveonce(server)

--- a/src/install.jl
+++ b/src/install.jl
@@ -21,7 +21,7 @@ Description=Julia ($(@__MODULE__).jl) server daemon
 [Service]
 Type=simple
 ExecStart=$(first(worker_cmd.exec)) --startup-file=no --project="$(dirname(@__DIR__))" -e "using $(@__MODULE__); $(@__MODULE__).start()"
-Environment="JULIA_DAEMON_SERVER=$MAIN_SOCKET"
+Environment="JULIA_DAEMON_SERVER=$(mainsocket())"
 Environment="JULIA_DAEMON_WORKER_EXECUTABLE=$(first(worker_cmd.exec))"
 $(if !haskey(ENV, "JULIA_DAEMON_WORKER_MAXCLIENTS")
     "Environment=\"JULIA_DAEMON_WORKER_MAXCLIENTS=$DEFAULT_WORKER_MAXCLIENTS\"\n"


### PR DESCRIPTION
Fixes --session and other no-value switches consuming the next argument as their value. E.g. juliaclient --session script.jl was parsing  as switch=("--session", "script.jl") instead of running script.jl