### PR TITLE
Handle io_uring socket errors gracefully

### DIFF
--- a/client/client.zig
+++ b/client/client.zig
@@ -366,7 +366,8 @@ fn run_ioring() !void {
             const cqe = try ring.copy_cqe();
 
             if (cqe.res < 0 and cqe.user_data != @intFromEnum(Location.stdin)) {
-                std.debug.panic("Oh no, something went wrong within io_uring.\n", .{}); }
+                std.debug.print("\n[juliaclient] Worker connection lost. Try: juliaclient --restart\n", .{});
+                std.process.exit(1); }
 
             switch (cqe.user_data) {
                 @intFromEnum(Location.stdout) => {

--- a/client/client.zig
+++ b/client/client.zig
@@ -365,7 +365,7 @@ fn run_ioring() !void {
         while (ring.cq_ready() > 0) {
             const cqe = try ring.copy_cqe();
 
-            if (cqe.res < 0 and cqe.user_data != @intFromEnum(Location.stdin)) {
+            if (cqe.res <= 0 and cqe.user_data != @intFromEnum(Location.stdin)) {
                 std.debug.print("\n[juliaclient] Worker connection lost. Try: juliaclient --restart\n", .{});
                 std.process.exit(1); }
 


### PR DESCRIPTION
When the worker connection is lost (e.g., worker crash), print a helpful message suggesting `juliaclient --restart` instead of panicking.