### PR TITLE
Remove auto Project.toml walk-up when no --project given

### DIFF
--- a/conductor/project.zig
+++ b/conductor/project.zig
@@ -5,7 +5,7 @@ const std = @import("std");
 const Io = std.Io;
 const args = @import("args.zig");
 
-/// Find project path from parsed args, environment, or by walking up from cwd.
+/// Find project path from parsed args or environment.
 /// Returns allocated string that caller must free, or null for default (@v#.#).
 pub fn resolve(
     allocator: std.mem.Allocator,
@@ -35,8 +35,8 @@ pub fn resolve(
         }
         return try allocator.dupe(u8, project);
     }
-    // 3. Walk up from cwd looking for Project.toml
-    return findProjectToml(allocator, io, cwd);
+    // No --project or JULIA_PROJECT: use default environment (@v#.#)
+    return null;
 }
 
 fn findProjectToml(allocator: std.mem.Allocator, io: Io, start_dir: []const u8) !?[]const u8 {


### PR DESCRIPTION
## Summary
- Without `--project` or `JULIA_PROJECT`, the conductor walked up from cwd to find `Project.toml` and activated that project — diverging from standard `julia` behavior which uses the default `@v#.#` environment.
- This caused unexpected project activation (and potential package loading failures) when running `juliaclient` in directories with unrelated `Project.toml` files.

## Test plan
- Run `juliaclient -e 'using SomePkg'` in a directory with a `Project.toml` that doesn't include `SomePkg` — should now use default env and succeed (if installed there)
- Run `juliaclient --project=. -e '...'` — should still correctly activate the local project
- Run `juliaclient --project=@. -e '...'` — should still walk up to find `Project.toml`